### PR TITLE
RR-395 - correct response type in swagger spec for new `/list` endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsciagcareersinductionapi/resource/CIAGResourceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsciagcareersinductionapi/resource/CIAGResourceController.kt
@@ -95,7 +95,7 @@ class CIAGResourceController(
         content = [
           Content(
             mediaType = "application/json",
-            schema = Schema(implementation = List::class),
+            schema = Schema(implementation = CIAGProfileListDTO::class),
           ),
         ],
       ),
@@ -119,7 +119,7 @@ class CIAGResourceController(
   fun getAllCIAGProfileForGivenOffenderIds(
     @Valid @RequestBody
     offenderIdList: CIAGProfileOffenderIdListRequestDTO,
-  ): CIAGProfileListDTO? {
+  ): CIAGProfileListDTO {
     return CIAGProfileListDTO(ciagProfileService.getAllCIAGProfileForGivenOffenderIds(offenderIdList.offenderIds))
   }
 


### PR DESCRIPTION
This PR corrects the response type in the swagger spec annotations for the `/list` endpoint
This is necessary to allow projects that codegen classes from the swagger spec to generate the request stubs and classes properly