### PR TITLE
RR-441 - Corrected attribute names in AchievedQualification for swagger spec

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsciagcareersinductionapi/entity/AchievedQualification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsciagcareersinductionapi/entity/AchievedQualification.kt
@@ -8,9 +8,9 @@ import javax.persistence.Embeddable
 data class AchievedQualification(
   @Schema(description = "This is the subject the inmate has chosen.", name = "subject", required = false)
   var subject: String?,
-  @Schema(description = "This is the grade on the subject the inmate has chosen.", name = "subject", required = false)
+  @Schema(description = "This is the grade on the subject the inmate has chosen.", name = "grade", required = false)
   var grade: String?,
-  @Schema(description = "This is the level of  the subject the inmate has chosen.", name = "subject", required = false)
+  @Schema(description = "This is the level of  the subject the inmate has chosen.", name = "level", required = false)
   var level: QualificationLevel?,
 ) {
   override fun equals(other: Any?): Boolean {


### PR DESCRIPTION
This PR corrects the attribute names in the generated swagger spec for the type `AchievedQualification`

We need this to be correct so that the swagger spec can be imported into the PLP UI so that it can codegen classes in order to consume the CIAG API (at the moment the generated AchievedQualification type in the PLP UI is wrong and is missing `grade` and `level`)