### PR TITLE
RR-530 Reduce replica count to 0, before the API is decommissioned

### DIFF
--- a/helm_deploy/hmpps-ciag-careers-induction-api/values.yaml
+++ b/helm_deploy/hmpps-ciag-careers-induction-api/values.yaml
@@ -1,7 +1,7 @@
 generic-service:
   nameOverride: hmpps-ciag-careers-induction-api
-
-  replicaCount: 4
+  ## TODO RR-530 - temporary measure until the API is fully decommissioned
+  replicaCount: 0
 
   image:
     repository: quay.io/hmpps/hmpps-ciag-careers-induction-api

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -2,7 +2,8 @@
 # Per environment values which override defaults in hmpps-ciag-careers-induction-api/values.yaml
 
 generic-service:
-  replicaCount: 2
+  ## TODO RR-530 - temporary measure until the API is fully decommissioned
+  replicaCount: 0
 
   ingress:
     host: ciag-induction-api-dev.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -2,7 +2,8 @@
 # Per environment values which override defaults in hmpps-ciag-careers-induction-api/values.yaml
 
 generic-service:
-  replicaCount: 2
+  ## TODO RR-530 - temporary measure until the API is fully decommissioned
+  replicaCount: 0
   
   ingress:
     host: ciag-induction-api-preprod.hmpps.service.justice.gov.uk


### PR DESCRIPTION
Now that the CIAG API has been migrated to the PLP API, this PR reduces the number of Spring Boot applications to reduce unnecessary resources. This is a temporarily measure until we properly decommission the API, including it's database.